### PR TITLE
Fix #11 by using Android SDK tool to accept licenses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,10 @@ jobs:
       - image: circleci/android:api-27-alpha
     environment:
       JVM_OPTS: -Xmx3200m
-      ANDROID_LICENSES: "/opt/android/sdk/licenses"
     steps:
       - run:
           name: Accept Licenses
-          command: mkdir -p $ANDROID_LICENSES &&
-                   echo d56f5187479451eabf01fb78af6dfcb131a6481e > $ANDROID_LICENSES/android-sdk-license &&
-                   echo 84831b9409646a918e30573bab4c9c91346d8abd > $ANDROID_LICENSES/android-sdk-preview-license &&
-                   echo d975f751698a77b662f1254ddbeed3901e976f5a > $ANDROID_LICENSES/intel-android-extra-license
+          command: yes | sdkmanager --licenses || true
       - checkout
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "katana/build.gradle" }}


### PR DESCRIPTION
# PROBLEM

Circle ci command step uses a fragile solution of hardcoded licenses.

# SOLUTION

Refactor command to use the android sdk accept licenses feature.

# ADDRESSES

Closes #11 